### PR TITLE
[18.0][FIX] edi_voxel_*: Pass report name instead of report record to

### DIFF
--- a/edi_voxel_oca/models/voxel_mixin.py
+++ b/edi_voxel_oca/models/voxel_mixin.py
@@ -50,7 +50,7 @@ class VoxelMixin(models.AbstractModel):
 
     # Export methods
     # --------------
-    def enqueue_voxel_report(self, report):
+    def enqueue_voxel_report(self, report_name):
         eta = self.company_id._get_voxel_report_eta()
         queue_obj = self.env["queue.job"].sudo()
         for record in self.sudo():
@@ -65,17 +65,17 @@ class VoxelMixin(models.AbstractModel):
             new_delay = (
                 record.with_context(company_id=self.company_id.id)
                 .with_delay(eta=eta)
-                ._get_and_send_voxel_report(report)
+                ._get_and_send_voxel_report(report_name)
             )
             job = queue_obj.search([("uuid", "=", new_delay.uuid)], limit=1)
             record.voxel_job_ids |= job
 
-    def _get_and_send_voxel_report(self, report):
+    def _get_and_send_voxel_report(self, report_name):
         self.ensure_one()
         # Support legacy enqueued jobs passing XML-ID
-        if isinstance(report, str):
-            report = self.env.ref(report)
-        report_xml = report._render_qweb_xml(self.ids, {})[0]
+        report_xml = self.env["ir.actions.report"]._render_qweb_xml(
+            report_name, self.ids, {}
+        )[0]
         # Remove blank spaces
         tree = etree.fromstring(report_xml, etree.XMLParser(remove_blank_text=True))
         clean_report_xml = etree.tostring(tree, xml_declaration=True, encoding="UTF-8")

--- a/edi_voxel_stock_picking_oca/models/stock_picking.py
+++ b/edi_voxel_stock_picking_oca/models/stock_picking.py
@@ -76,11 +76,11 @@ class Picking(models.Model):
         pickings = self.filtered(able_to_voxel)
         if pickings:
             for picking in pickings:
-                report = picking.partner_id.voxel_picking_report_id or self.env.ref(
-                    "edi_voxel_stock_picking_oca.report_voxel_picking"
+                report_name = (
+                    picking.partner_id.voxel_picking_report_id.report_name
+                    or "edi_voxel_stock_picking_oca.report_voxel_picking"
                 )
-                if report:
-                    picking.enqueue_voxel_report(report)
+                picking.enqueue_voxel_report(report_name)
 
     def get_document_type(self):
         """Document type name to be used in the name of the Voxel report"""

--- a/edi_voxel_stock_picking_oca/tests/test_voxel_stock_picking.py
+++ b/edi_voxel_stock_picking_oca/tests/test_voxel_stock_picking.py
@@ -3,8 +3,6 @@
 
 from datetime import datetime
 
-from odoo.tests import Form
-
 from odoo.addons.base.tests.common import BaseCommon
 
 
@@ -47,7 +45,12 @@ class TestVoxelStockPickingCommon(BaseCommon):
             }
         )
         cls.product = cls.env["product.product"].create(
-            {"default_code": "DC_001", "name": "Product 1 (test)", "type": "consu"}
+            {
+                "default_code": "DC_001",
+                "name": "Product 1 (test)",
+                "type": "consu",
+                "is_storable": True,
+            }
         )
         cls.env["product.customerinfo"].create(
             {
@@ -62,6 +65,7 @@ class TestVoxelStockPickingCommon(BaseCommon):
                 "default_code": "DC_002",
                 "name": "Product 2 (test)",
                 "type": "consu",
+                "is_storable": True,
                 "tracking": "lot",
             }
         )
@@ -88,18 +92,11 @@ class TestVoxelStockPickingCommon(BaseCommon):
             }
         )
         sm = cls.picking.move_ids[0]
-        sm.write({"quantity": sm.product_uom_qty})
+        sm.write({"quantity": sm.product_uom_qty, "picked": True})
         sm = cls.picking.move_ids[1]
-        sm.write({"quantity": sm.product_uom_qty})
+        sm.write({"quantity": sm.product_uom_qty, "picked": True})
         sm.move_line_ids.lot_id = cls.lot.id
-        backorder_wizard_dict = cls.picking.button_validate()
-        # pylint: disable=W8121
-        backorder_wizard = Form(
-            cls.env[backorder_wizard_dict["res_model"]].with_context(
-                backorder_wizard_dict["context"]
-            )
-        ).save()
-        backorder_wizard.process()
+        cls.picking._action_done()
 
     @classmethod
     def _create_sale_order(cls):


### PR DESCRIPTION
Make enqueue_voxel_report and _get_and_send_voxel_report work with the report name and render it through ir.actions.report._render_qweb_xml, and update action_send_to_voxel accordingly.

cc @Tecnativa TT62988

ping @sergio-teruel @juancarlosonate-tecnativa 